### PR TITLE
(debug) Remove pdk and bolt commands

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -91,8 +91,7 @@ jobs:
         run: |
           choco install -y pdk puppet-bolt
 
-          pdk --version
-          bolt --version
+          Write-Host 'done!'
       - name: Install 1password CLI
         run: |
           choco install -y 1password-cli

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -91,9 +91,7 @@ jobs:
     steps:
       - name: Install Bolt
         run: |
-          choco install -y pdk puppet-bolt
-
-          Get-ChildItem -Path Env:
+          choco install -y puppet-bolt
 
           bolt --version
       - name: Install 1password CLI
@@ -103,9 +101,26 @@ jobs:
           op --version
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5.x'
+      - name: Install bundler
+        run: |
+          gem install bundler
+          bundle config path .bundle/lib
+      - name: Cache gems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: .bundle/lib
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+      - name: Install gems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
       - name: Provision test fixtures
         run: |
-          pdk bundle exec rake spec_prep
+          bundle exec rake spec_prep
       - name: Run acceptance tests
         env:
           OP_TEST_PASSWORD: '${{ secrets.OP_TEST_PASSWORD }}'

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -10,6 +10,8 @@ on:
   repository_dispatch:
     types: [acceptance_tests]
 
+env:
+  PDK_FRONTEND: noninteractive
 
 jobs:
   linux:
@@ -91,7 +93,11 @@ jobs:
         run: |
           choco install -y pdk puppet-bolt
 
-          Write-Host 'done!'
+          Get-ChildItem -Path Env:
+
+          bolt --version
+          pdk --version
+
       - name: Install 1password CLI
         run: |
           choco install -y 1password-cli

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -96,8 +96,6 @@ jobs:
           Get-ChildItem -Path Env:
 
           bolt --version
-          pdk --version
-
       - name: Install 1password CLI
         run: |
           choco install -y 1password-cli


### PR DESCRIPTION
The `choco install` step in the windows acceptance tests is hanging
indefinitely. Canceling shows that installation completes, so this
commit yanks the `pdk` and `bolt` commands to see if they are the
problem.